### PR TITLE
Reference to poke_ratio changed to a more general reference

### DIFF
--- a/USMapPoke.js
+++ b/USMapPoke.js
@@ -120,7 +120,7 @@ function drawTheUSPokeRatioMap(){
 	
 	//Build map
 	var map = gradientMap.setColors("#002966","#B2D1FF")
-				.setFeature("Poke Ratio")
+				.setFeature("poke_ratio")
 				.setRestFileName("poke.csv")
 				//.setDrawCounties(drawCounties)
 				.setFunctions(getStateValuesFunction, getCountyValuesFunction)

--- a/gradientUSMap.js
+++ b/gradientUSMap.js
@@ -88,8 +88,8 @@
 
 		d3.csv(csvUSValueFile, function(data) {
 
-            min = d3.min(data, function(d) { return +d.poke_ratio; }).toString();
-            max = d3.max(data, function(d) { return +d.poke_ratio; }).toString();
+            min = d3.min(data, function(d) { return +d[feature_desired]; }).toString();
+            max = d3.max(data, function(d) { return +d[feature_desired]; }).toString();
             
 
 			if (!continuous) {
@@ -517,9 +517,10 @@
 		}
 
         d3.csv(countyValuePath+csvFile, function(data) {
-
-            min = d3.min(data, function(d) { return +d.poke_ratio; }).toString();
-            max = d3.max(data, function(d) { return +d.poke_ratio; }).toString();
+			
+			
+            min = d3.min(data, function(d) { return +d[feature_desired]; }).toString();
+            max = d3.max(data, function(d) { return +d[feature_desired]; }).toString();
             //test edit
             //document.write(d3.min(data, function(d) { return +d.poke_ratio; }));
             


### PR DESCRIPTION
Allows other names to be passed through to be referenced instead of just poke_ratio. Working on getting rid of the display of "poke_ratio" and changing it to say something like "Poke Ratio".
