### PR TITLE
DC is visualized in US view

### DIFF
--- a/USMapPoke.js
+++ b/USMapPoke.js
@@ -67,6 +67,7 @@ function drawTheUSPokeRatioMap(){
 	state_abbreviations["California"] = "CA";
 	state_abbreviations["Colorado"] = "CO";
 	state_abbreviations["Connecticut"] = "CT";
+	state_abbreviations["District of Columbia"] = "DC";
 	state_abbreviations["Delaware"] = "DE";
 	state_abbreviations["Florida"] = "FL";
 	state_abbreviations["Georgia"] = "GA";


### PR DESCRIPTION
DC is visualized in US view and is drawn in county view, but visual glitch renders it in all black. The color scale also shows two colors when there will only be one color in DC. We will discuss what to do about that.
