### PR TITLE
Correcting the link on the picture for the doctor misclassification slot on the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
 			<!--DoctorMisclassificationProject-->
 			<div class="row">
-				<a href="#"><img class="thumb img-responsive" src="DoctorMisclassification/images/thumbnailwhite.png" height="336" width="450"></a>
+				<a href="DoctorMisclassification/doctorMisclassification.html"><img class="thumb img-responsive" src="DoctorMisclassification/images/thumbnailwhite.png" height="336" width="450"></a>
 				<h3><a href="DoctorMisclassification/doctorMisclassification.html">Identifying Misclassifications of Doctors in Medicare Data</a></h3>
 				<p> Medicare data is notorious for having incorrect information. Fred Trotter estimates that 30% of doctors inside the Medicare Bill data from 2014 recorded incorrect addresses. With that knowledge, we took the initiative to explore how many doctors could possibly be misclassified inside the 2014 Medicare Billing data. </p>
 


### PR DESCRIPTION
Link originally was just reloading page. Just updates the link to the specific page for the project instead.
